### PR TITLE
Runtime migration of flows

### DIFF
--- a/app/src/androidTest/java/io/rapidpro/surveyor/engine/EngineTest.java
+++ b/app/src/androidTest/java/io/rapidpro/surveyor/engine/EngineTest.java
@@ -32,23 +32,16 @@ public class EngineTest extends BaseApplicationTest {
 
     @Test
     public void currentSpecVersion() {
-        assertThat(Engine.currentSpecVersion(), is(new Semver("13.0.0")));
+        assertThat(Engine.currentSpecVersion(), is(new Semver("13.1.0")));
     }
 
     @Test
     public void isSpecVersionSupported() {
-        assertThat(Engine.isSpecVersionSupported("12.0"), is(false));
+        assertThat(Engine.isSpecVersionSupported("10.0"), is(false));
+        assertThat(Engine.isSpecVersionSupported("11.0"), is(true));
         assertThat(Engine.isSpecVersionSupported("13.0"), is(true));
         assertThat(Engine.isSpecVersionSupported("13.5"), is(true));
         assertThat(Engine.isSpecVersionSupported("14.0"), is(false));
-    }
-
-    @Test
-    public void migrateLegacyDefinition() {
-        String legacyFlow = "{\"action_sets\":[],\"rule_sets\":[],\"base_language\":\"eng\",\"metadata\":{\"uuid\":\"061be894-4507-470c-a20b-34273bf915be\",\"name\":\"Survey\"}}";
-        String migrated = Engine.migrateLegacyDefinition(legacyFlow);
-
-        assertThat(migrated, is("{\"uuid\":\"061be894-4507-470c-a20b-34273bf915be\",\"name\":\"Survey\",\"spec_version\":\"13.0.0\",\"language\":\"eng\",\"type\":\"messaging\",\"revision\":0,\"expire_after_minutes\":0,\"localization\":{},\"nodes\":[],\"_ui\":{\"nodes\":{},\"stickies\":{}}}"));
     }
 
     @Test(expected = EngineException.class)

--- a/app/src/androidTest/java/io/rapidpro/surveyor/net/TembaServiceTest.java
+++ b/app/src/androidTest/java/io/rapidpro/surveyor/net/TembaServiceTest.java
@@ -189,7 +189,7 @@ public class TembaServiceTest extends BaseApplicationTest {
 
         // check flow definitions have been migrated
         assertThat(definitions, hasSize(3));
-        assertThat(definitions.get(0).toString(), startsWith("{\"uuid\":\"ed8cf8d4-a42c-4ce1-a7e3-44a2918e3cec\",\"name\":\"Contact Details\""));
+        assertThat(definitions.get(0).toString(), startsWith("{\"entry\":\"036901e0-abb8-4979-92cb-f0d43aeb5b68\""));
     }
 
     /**

--- a/app/src/main/java/io/rapidpro/surveyor/engine/Engine.java
+++ b/app/src/main/java/io/rapidpro/surveyor/engine/Engine.java
@@ -45,30 +45,6 @@ public class Engine {
     }
 
     /**
-     * Returns whether the given definition is in legacy format
-     *
-     * @param definition the legacy definition
-     * @return true if definition is legacy
-     */
-    public static boolean isLegacyDefinition(String definition) {
-        return Mobile.isLegacyDefinition(definition);
-    }
-
-    /**
-     * Migrates a legacy flow definition to the new engine format
-     *
-     * @param definition the legacy definition
-     * @return the new definition
-     */
-    public static String migrateLegacyDefinition(String definition) {
-        try {
-            return Mobile.migrateLegacyDefinition(definition);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
      * Gets the current spec version
      *
      * @return the spec version
@@ -84,7 +60,12 @@ public class Engine {
      * @return true if supported
      */
     public static boolean isSpecVersionSupported(String ver) {
-        return Mobile.isSpecVersionSupported(ver);
+        // for a while Surveyor was creating v12 flows which don't exist anywhere else
+        if (ver.startsWith("12.")) {
+            return false;
+        }
+
+        return Mobile.isVersionSupported(ver);
     }
 
     /**

--- a/app/src/main/java/io/rapidpro/surveyor/net/TembaService.java
+++ b/app/src/main/java/io/rapidpro/surveyor/net/TembaService.java
@@ -184,19 +184,7 @@ public class TembaService {
             checkResponse(response);
 
             Definitions definitions = response.body();
-            List<RawJson> flowDefs = new ArrayList<>(definitions.getFlows().size());
-
-            for (RawJson rawFlow : definitions.getFlows()) {
-                if (Engine.isLegacyDefinition(rawFlow.toString())) {
-                    String migrated = Engine.migrateLegacyDefinition(rawFlow.toString());
-                    flowDefs.add(new RawJson(migrated));
-                } else {
-                    flowDefs.add(rawFlow);
-                }
-            }
-
-            return flowDefs;
-
+            return definitions.getFlows();
 
         } catch (IOException e) {
             throw new TembaException("Unable to fetch definitions", e);


### PR DESCRIPTION
Update to latest goflow where flow migration happens automatically in `ReadFlow`. This avoids the problem of migrating and saving flows, only for them to become too old for a newer version of the app.